### PR TITLE
disable <a> generation with empty anchorText

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,11 +37,16 @@ function HeaderIds(options /*:Partial<Options>*/) {
       if (appliedOptions.levels.indexOf(hLevel) !== -1) {
         return `<h${hLevel} id="${appliedOptions.headerId(
           slug
-        )}"><a class="${
-          appliedOptions.anchorClassName
-        }" id="${slug}" href="${href}">${
-          appliedOptions.anchorText
-        }</a>`;
+        )}">` 
+        + (
+          appliedOptions.anchorText ?
+            `<a class="${
+              appliedOptions.anchorClassName
+            }" id="${slug}" href="${href}">${
+              appliedOptions.anchorText
+            }</a>`
+          : ''
+        );
       }
 
       return originalOpen(tokens, idx);


### PR DESCRIPTION
If anchorText is set to an empty string, the link is already unclickable.
For a better accessibility to screen readers, I remove the <a> generation in that specific case.